### PR TITLE
jekyll-plugin(prettifier.rb): support tag="code" argument

### DIFF
--- a/src/_plugins/prettify.rb
+++ b/src/_plugins/prettify.rb
@@ -3,36 +3,51 @@
 # BSD-style license that can be found in the LICENSE file.
 
 require 'cgi'
+require 'liquid/tag/parser' # https://github.com/envygeeks/liquid-tag-parser
 
 module Prettify
 
   # Wraps code with tags for Prettify.
   #
+  # Arguments:
+  #
+  # - The first unnamed optional argument is the prettifier lang argument.
+  #   Use 'nocode' or 'none' as the language to turn of prettifying.
+  # - class="..."
+  # - tag="code|pre". The prettified code will be wrapped in this HTML tag.
+  #   Default is pre.
+  #
   # Example usage:
   #
   # {% prettify dart %}
-  # // dart code here
+  # var hello = 'world';
   # {% endprettify %}
-  #
-  # The language name can be ommitted if it is not known.
-  # Use 'nocode' or 'none' as the language to turn of prettifying.
 
   class Tag < Liquid::Block
 
-    Syntax = /\s*(\w+)\s*/o
-
-    def initialize(tag_name, markup, tokens)
+    def initialize(tag_name, stringOfArgs, tokens)
       super
-      @lang = $1 if markup =~ Syntax
+      @args = Liquid::Tag::Parser.new(stringOfArgs).args
+      @lang = @args[:argv1]
+      @tag = @args[:tag] || 'pre'
+      initCssClasses
+    end
+
+    def initCssClasses
+      @cssClasses = []
+      unless @lang == 'nocode' || @lang == 'none'
+        @cssClasses << 'prettyprint'
+        @cssClasses << "lang-#{@lang}" if @lang
+      end
+      @cssClasses << @args[:class] if @args[:class]
+    end
+
+    def classAttr
+      @cssClasses.empty? ? '' : " class=\"#{@cssClasses.join(' ')}\""
     end
 
     def render(context)
-      out = '<pre class="'
-      unless @lang == 'nocode' || @lang == 'none'
-        out += 'prettyprint'
-        out += ' lang-' + @lang if @lang
-      end
-      out += '">'
+      out = "<#{@tag}#{classAttr}>"
 
       # Strip excess whitespace at the end (which will be present if the code is indented)
       contents = super.gsub /(\s*\n\s*)+\z/, ''
@@ -53,7 +68,7 @@ module Prettify
       contents.gsub!('[[red]]', '<code class="nocode red">')
       contents.gsub!('[[/red]]', '</code>')
 
-      out += contents + "</pre>"
+      out += contents + "</#{@tag}>"
     end
 
   end


### PR DESCRIPTION
Add support for `tag` and `class` arguments to prettifier tag.